### PR TITLE
Add support for jenkins with CSRF prevention enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,12 @@ Options:
   --dry-run     Don't install any packages on jenkins
 ```
 
+Configuration File
+-----
+```
+[jenkins]
+user=admin                # Jenkins user id
+password=admin            # Jenkins user password
+url=http://localhost:8080 # Jenkins url
+csrf_enabled=false        # Set to 'true' if Prevent Cross Site Request Forgery exploits is enabled
+```

--- a/config.ini
+++ b/config.ini
@@ -2,3 +2,4 @@
 user=admin
 password=admin
 url=http://localhost:8080
+csrf_enabled=false

--- a/jpinstall/cli.py
+++ b/jpinstall/cli.py
@@ -75,8 +75,9 @@ def main():
     user = config.get('jenkins', 'user')
     password = config.get('jenkins', 'password')
     url = config.get('jenkins', 'url')
+    csrf_enabled = config.get('jenkins', 'csrf_enabled')
 
-    jenkins = JenkinsPlugins(url, user, password)
+    jenkins = JenkinsPlugins(url, user, password, csrf_enabled)
 
     if opts['list']:
         list_plugins(jenkins.plugins())


### PR DESCRIPTION
CSRF prevention is enabled by default in Jenkins 2.x. A CSRF token must be sent with each POST request otherwise the following error will be received [[1](https://wiki.jenkins.io/display/JENKINS/Remote+access+API#RemoteaccessAPI-CSRFProtection)] :

```
403 Client Error: No valid crumb was included in the request
```

- [x] Add a `csrf_enabled` property in the **config.ini** to be set to either `true` or `false` if CSRF prevention is enabled in the Jenkins instance.
- [x] Add a function to get the CSRF field and token from the Jenkins crumb issuer. Add this to the header of each POST request.
- [x] Add section to the readme to document the **config.ini** properties

### Verification Steps

1. Run `python setup.py install`
2. Configure the values in the config.ini to point to a Jenkins instance
3. Set csrf_enabled to `false` and run `jpi version`
   - Verify that the error above is received
4. Set csrf_enabled to `true` and run `jpi version`.
   - Verify that the command runs successfully

