### PR TITLE
Add crumb token post reqs

### DIFF
--- a/jpinstall/jenkins.py
+++ b/jpinstall/jenkins.py
@@ -66,8 +66,7 @@ class JenkinsPlugins(object):
     def install_plugins(self, plugins, downloaded):
         remaining = downloaded
         while len(remaining) > 0:
-            print("Remaining: ", len(remaining))
-            print("Values: ", remaining)
+            print("Remaining plugins to be installed: ", remaining)
             installed = self.plugins()
             installable, remaining = installable_downloads(installed, plugins, downloaded)
             self.upload_plugins(installable)
@@ -104,7 +103,6 @@ class JenkinsPlugins(object):
                 headers= headers,
                 verify=False,
                 files={'files':hpi})
-            print response.status_code
             response.raise_for_status()
             return response
 

--- a/jpinstall/jenkins.py
+++ b/jpinstall/jenkins.py
@@ -66,6 +66,8 @@ class JenkinsPlugins(object):
     def install_plugins(self, plugins, downloaded):
         remaining = downloaded
         while len(remaining) > 0:
+            print("Remaining: ", len(remaining))
+            print("Values: ", remaining)
             installed = self.plugins()
             installable, remaining = installable_downloads(installed, plugins, downloaded)
             self.upload_plugins(installable)
@@ -90,12 +92,19 @@ class JenkinsPlugins(object):
         """
         Uploads a file to the plugin upload endpoint of jenkins.
         """
+        headers = {}
+        if self.csrf_enabled == 'true':
+            csrf_field, csrf_token = self.get_csrf_token()
+            headers[csrf_field] = csrf_token
+
         with open(path, 'rb') as hpi:
             response = requests.post(
                 self.url+"/pluginManager/uploadPlugin",
                 auth=(self.username, self.password),
+                headers= headers,
                 verify=False,
                 files={'files':hpi})
+            print response.status_code
             response.raise_for_status()
             return response
 
@@ -122,9 +131,15 @@ class JenkinsPlugins(object):
         Triggers a restart of the jenkins server
         """
         try:
+            headers = {}
+            if self.csrf_enabled == 'true':
+                csrf_field, csrf_token = self.get_csrf_token()
+                headers[csrf_field] = csrf_token
+
             response = requests.post(
                 self.url + "/safeRestart",
                 auth=(self.username, self.password),
+                headers= headers,
                 verify=False)
             response.raise_for_status()
         except Exception as ex:


### PR DESCRIPTION
## What
This is a follow up on https://github.com/feedhenry/jenkins-plugin-install/pull/7 which adds support for Jenkins instances that has CSRF prevention enabled. 

- [x] Add the crumb token to the POST request sent to the plugin upload endpoint if the `csrf_enabled` property is set to true
- [x] Add the crumb token to the POST request sent to the restart endpoint if the `csrf_enabled` property is set to true